### PR TITLE
Fix: Can't connect to X11 window server

### DIFF
--- a/app/services/svg_export/command_wrapper.rb
+++ b/app/services/svg_export/command_wrapper.rb
@@ -40,7 +40,7 @@ module SvgExport
     protected
 
     def run!
-      cmd = "java -jar #{Engine.batik_path} -m #{type} -d #{outfile.path} #{width} #{infile.path} 2>&1"
+      cmd = "java -Djava.awt.headless=true -jar #{Engine.batik_path} -m #{type} -d #{outfile.path} #{width} #{infile.path} 2>&1"
       result = `#{cmd}`
       if result.index("success").nil?
         raise SvgExport::Error.new(result)


### PR DESCRIPTION
* We can run java in headless mode to avoid the error
* Readmore: https://www.oracle.com/technical-resources/articles/javase/headless.html